### PR TITLE
fix: added restart threshold as a band-aid to mitigate controller lockup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirebotics/urscript-tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2619,8 +2619,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2641,14 +2640,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2663,20 +2660,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2793,8 +2787,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2806,7 +2799,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2821,7 +2813,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2829,14 +2820,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2855,7 +2844,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2936,8 +2924,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2949,7 +2936,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3035,8 +3021,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3072,7 +3057,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3092,7 +3076,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3136,14 +3119,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/cli/tester-cli.ts
+++ b/src/cli/tester-cli.ts
@@ -151,6 +151,7 @@ const main = async () => {
       runner: new URScriptRunner(scriptRunnerConfig),
       port: config.testServer.port,
       executionTimeout: config.testServer.defaultExecutionTimeout,
+      restartThreshold: config.testServer.restartThreshold
     };
 
     const executionConfig: ITestExecutionConfig = {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -16,6 +16,7 @@ export interface IURTesterCliConfig {
     host: string;
     port: number;
     defaultExecutionTimeout: number;
+    restartThreshold?: number;
   };
   mocks: FilePattern;
   sources: IBundleSources;

--- a/src/examples/urtester.config.full.json
+++ b/src/examples/urtester.config.full.json
@@ -13,7 +13,8 @@
   "testServer": {
     "host": "autodiscover",
     "port": 24493,
-    "defaultExecutionTimeout": 10000
+    "defaultExecutionTimeout": 10000,
+    "restartThreshold": 30
   },
   "mocks": {
     "include": ["__mocks__/**/*.mock.script"]

--- a/src/runner/URScriptRunner.ts
+++ b/src/runner/URScriptRunner.ts
@@ -67,14 +67,14 @@ export class URScriptRunner implements IScriptRunner {
     }
   }
 
-  public async shutdown(): Promise<void> {
+  public async shutdown(kill: boolean = false): Promise<void> {
     if (this.logTail) {
       logger.info('shutting down urcontroller log monitor');
       this.logTail.kill();
       this.logTail = undefined;
     }
 
-    if (this.config.controller.autoStop) {
+    if (kill || this.config.controller.autoStop) {
       await this.stop();
     }
   }

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -11,5 +11,5 @@ export interface IScriptRunnerConfig {
 export interface IScriptRunner {
   send(script: string): Promise<void>;
   launch(): Promise<boolean>;
-  shutdown(): Promise<void>;
+  shutdown(kill?: boolean): Promise<void>;
 }

--- a/src/urtester/types.ts
+++ b/src/urtester/types.ts
@@ -43,6 +43,7 @@ export interface ITestRunnerConfig {
   runner: IScriptRunner;
   port: number;
   executionTimeout: number;
+  restartThreshold?: number;
 }
 
 export interface ITestRunner {


### PR DESCRIPTION
When running a large number of unit test there are instances where the container can lock up. This is a band-and fix to recycle the container after a threshold has been reach on test invocations. By default, this feature is not turned on, but a user can control via config entry. 