### PR TITLE
chore: switched buildspec to publish to npm

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,15 +1,12 @@
 version: 0.2
 env:
   parameter-store:
-    GITHUB_TOKEN: /github/automation_token
+    NPM_TOKEN: /npm/automation_token
   git-credential-helper: yes
 phases:
   install:
     runtime-versions:
       nodejs: 10
-  pre_build:
-    commands:
-      - echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > .npmrc
   build:
     commands:
       - npm i

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/Hirebotics/urscript-tools.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "access": "public"
   },
   "keywords": [
     "universal",


### PR DESCRIPTION
PR switches CI process to publish releases to npm instead of GitHub packages