### PR TITLE
fix: fixed error if textmsg was invoked with a non-string data type

### DIFF
--- a/src/runner/templates/harness.script
+++ b/src/runner/templates/harness.script
@@ -28,8 +28,8 @@ def urscript_runner():
     end
   end
 
-  def runner_log_message(message):
-    local message = runner_createKeyValuePair("message", message)
+  def runner_log_message(str1, str2 = ""):
+    local message = runner_createKeyValuePair("message", str_cat(str1, str2))
     local type = runner_createKeyValuePair("type", "LOG_MESSAGE", False)
 
     runner_notifyServer(


### PR DESCRIPTION
Updated internal `runner_log_message` to match `textmsg` signature and concat strings before sending to server