### PR TITLE
Ability to strip comments. Various bug fixes.

### DIFF
--- a/src/bundler/BundlerService.ts
+++ b/src/bundler/BundlerService.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, merge } from 'lodash';
 import * as mkdirp from 'mkdirp';
 import moment from 'moment';
 
@@ -42,11 +42,7 @@ export class BundlerService implements IBundlerService {
   };
 
   constructor(config?: IBundlerConfig) {
-    // TODO perform deep merge instead of spread
-    this.config = {
-      ...this.config,
-      ...config,
-    };
+    merge(this.config, config);
   }
 
   public async bundleAll(): Promise<IBundles> {

--- a/src/bundler/BundlerService.ts
+++ b/src/bundler/BundlerService.ts
@@ -32,7 +32,7 @@ export class BundlerService implements IBundlerService {
       global: {},
     },
     options: {
-      bundleKey: 'default',
+      bundleKey: '',
       outputDir: 'bundle-dist',
       writeToDisk: true,
       scriptSuffix: 'script',
@@ -100,7 +100,7 @@ export class BundlerService implements IBundlerService {
 
     if (!hasPermutations) {
       const defaultBundleKey = this.config.options.bundleKey as string;
-      if (global && defaultBundleKey) {
+      if (global) {
         bundles[defaultBundleKey] = this.createBundle(defaultBundleKey, global);
       }
     } else if (permutations) {

--- a/src/bundler/types.ts
+++ b/src/bundler/types.ts
@@ -4,9 +4,9 @@ export interface IBundlerConfig {
     bundleKey?: string;
     bundleOutputFile?: string;
     outputDir?: string;
-    appendGitCommitHash?: boolean;
     writeToDisk?: boolean;
     scriptSuffix?: string;
+    stripComments?: boolean;
   };
 }
 

--- a/src/examples/bundle.config.simple.json
+++ b/src/examples/bundle.config.simple.json
@@ -12,6 +12,7 @@
     "bundleOutputFile": "program",
     "scriptSuffix": "script",
     "outputDir": "dist",
-    "writeToDisk": true
+    "writeToDisk": true,
+    "stripComments": true
   }
 }

--- a/src/urtester/TestExecutionService.ts
+++ b/src/urtester/TestExecutionService.ts
@@ -7,7 +7,12 @@ import { FilePattern, IBundle, IBundles } from '../bundler/types';
 import { getFilePaths, getFilesFromPatterns } from '../util/BundleUtils';
 import { getDockerHost } from '../util/docker';
 import { logger } from '../util/logger';
-import { ITestExecutionConfig, ITestExecutionService, ITestFile, ITestResult } from './types';
+import {
+  ITestExecutionConfig,
+  ITestExecutionService,
+  ITestFile,
+  ITestResult
+} from './types';
 
 export class TestExecutionService implements ITestExecutionService {
   private config: ITestExecutionConfig;
@@ -34,7 +39,7 @@ export class TestExecutionService implements ITestExecutionService {
 
     const bundles = await bundler.bundleAll();
     const promises = files.map(
-      async file => await this.createTests(file, bundles)
+      async (file) => await this.createTests(file, bundles)
     );
 
     const { writer } = this.config.results;
@@ -74,7 +79,7 @@ export class TestExecutionService implements ITestExecutionService {
       bundles,
     });
 
-    const tests = Object.values(bundles).map(bundle =>
+    const tests = Object.values(bundles).map((bundle) =>
       this.createTest(testFile, bundle)
     );
 
@@ -123,7 +128,7 @@ export class TestExecutionService implements ITestExecutionService {
       let merged = code;
 
       if (files) {
-        files.forEach(f => {
+        files.forEach((f) => {
           const mockDefinitions = readFileSync(f).toString();
           merged += `# ${f}\n\n${mockDefinitions}\n`;
         });
@@ -163,7 +168,7 @@ export class TestExecutionService implements ITestExecutionService {
 
         mockedCode = mockedCode
           .split('\n')
-          .map(line => {
+          .map((line) => {
             let modified = line.trim();
 
             if (
@@ -176,7 +181,7 @@ export class TestExecutionService implements ITestExecutionService {
 
             if (modified.indexOf(overrideFunctionName) > -1) {
               return line.replace(
-                new RegExp(`(?<!_)${overrideFunctionName}\\(`, 'g'),
+                new RegExp(`(?<!_|[A-Za-z])${overrideFunctionName}\\(`, 'g'),
                 `${mock}(`
               );
             }
@@ -239,7 +244,7 @@ export class TestExecutionService implements ITestExecutionService {
 
       mergedCode += `\ntest_framework_initialize("${host}", ${port})\n`;
 
-      tests.forEach(test => {
+      tests.forEach((test) => {
         let testExecutionCode = `
           test_framework_internal_beforeEach("${test}")
           ${hasBeforeEach ? 'beforeEach()' : '# no before each block defined'}
@@ -250,7 +255,7 @@ export class TestExecutionService implements ITestExecutionService {
 
         testExecutionCode = testExecutionCode
           .split('\n')
-          .map(line => line.trim())
+          .map((line) => line.trim())
           .join('\n');
 
         mergedCode += `${testExecutionCode}`;
@@ -270,7 +275,7 @@ export class TestExecutionService implements ITestExecutionService {
       // inject tabs into each line of modified script
       tabbedCode = tabbedCode
         .split('\n')
-        .map(line => `\t${line}`)
+        .map((line) => `\t${line}`)
         .join('\n');
     }
 
@@ -309,9 +314,9 @@ export class TestExecutionService implements ITestExecutionService {
 
     if (results) {
       return results
-        .map(t => t.trim())
-        .filter(t => !t.startsWith('#'))
-        .map(t => t.replace(/(def|thread)[\s]*/g, '').replace('(', ''));
+        .map((t) => t.trim())
+        .filter((t) => !t.startsWith('#'))
+        .map((t) => t.replace(/(def|thread)[\s]*/g, '').replace('(', ''));
     }
 
     return [];

--- a/src/urtester/TestExecutionService.ts
+++ b/src/urtester/TestExecutionService.ts
@@ -99,12 +99,19 @@ export class TestExecutionService implements ITestExecutionService {
     let testCode = await this.getFileContents(testFile, testFile);
 
     // take the test code and inject the global mocks definition code into it
-    testCode = await this.injectGlobalMockDefinitions(testCode);
+    testCode = await URTestUtils.appendCodeFromFilePattern(
+      testCode,
+      this.config.mocks
+    );
 
     let merged = shared;
 
-    merged = await this.injectTestCode(merged, testCode);
-    merged = await this.injectMockFunctions(merged, testCode);
+    merged = URTestUtils.appendCode(merged, testCode);
+    merged = URTestUtils.replaceInvocationsWithMocks(
+      merged,
+      URTestUtils.getMockDefinitions(testCode)
+    );
+
     merged = await this.injectTestExecution(merged, testCode);
     merged = await this.injectIntoHarness(merged);
 
@@ -118,82 +125,6 @@ export class TestExecutionService implements ITestExecutionService {
       file: testFile,
       group: bundle.name,
     };
-  }
-
-  private async injectGlobalMockDefinitions(code: string): Promise<string> {
-    const pattern: FilePattern = this.config.mocks;
-
-    if (pattern) {
-      const files = getFilePaths(pattern);
-
-      let merged = code;
-
-      if (files) {
-        files.forEach((f) => {
-          const mockDefinitions = readFileSync(f).toString();
-          merged += `# ${f}\n\n${mockDefinitions}\n`;
-        });
-      }
-
-      return merged;
-    }
-
-    return code;
-  }
-
-  private async injectTestCode(
-    code: string,
-    testCode: string
-  ): Promise<string> {
-    return `${code}\n\n${testCode}\n`;
-  }
-
-  private async injectMockFunctions(
-    code: string,
-    testCode: string
-  ): Promise<string> {
-    let mockedCode = code;
-
-    const mocks = URTestUtils.extractMocks(testCode);
-
-    if (mocks && mocks.length > 0) {
-      // replace function definition in the merged file with
-      // the mock implementation function name
-
-      for (const mock of mocks) {
-        // get the function name to override
-        const overrideFunctionName = mock.replace(/mock\_/, '');
-
-        // replace references of the override name in the merged script
-        // with the mock function name
-
-        mockedCode = mockedCode
-          .split('\n')
-          .map((line) => {
-            let modified = line.trim();
-
-            if (
-              modified.startsWith('def') ||
-              modified.startsWith('thread') ||
-              modified.startsWith('#')
-            ) {
-              return line;
-            }
-
-            if (modified.indexOf(overrideFunctionName) > -1) {
-              return line.replace(
-                new RegExp(`(?<!_|[A-Za-z])${overrideFunctionName}\\(`, 'g'),
-                `${mock}(`
-              );
-            }
-
-            return line;
-          })
-          .join('\n');
-      }
-    }
-
-    return mockedCode;
   }
 
   /**
@@ -220,67 +151,11 @@ export class TestExecutionService implements ITestExecutionService {
 
     let mergedCode = code;
 
-    const tests = URTestUtils.extractTests(testCode);
-
-    // append execute of each test below with a call to beforeEach if it exists
-    if (tests) {
-      const testLifecycleBeforeEach = URTestUtils.getDefinitionByRegex(
-        testCode,
-        /.*beforeEach\(/g
-      );
-      const testLifecycleAfterEach = URTestUtils.getDefinitionByRegex(
-        testCode,
-        /.*afterEach\(/g
-      );
-
-      const hasBeforeEach =
-        testLifecycleBeforeEach && testLifecycleBeforeEach.length === 1
-          ? true
-          : false;
-
-      const hasAfterEach =
-        testLifecycleAfterEach && testLifecycleAfterEach.length === 1
-          ? true
-          : false;
-
-      mergedCode += `\ntest_framework_initialize("${host}", ${port})\n`;
-
-      tests.forEach((test) => {
-        let testExecutionCode = `
-          test_framework_internal_beforeEach("${test}")
-          ${hasBeforeEach ? 'beforeEach()' : '# no before each block defined'}
-          ${test}()
-          ${hasAfterEach ? 'afterEach()' : '# no after each block defined'}
-          test_framework_internal_afterEach("${test}")
-        `;
-
-        testExecutionCode = testExecutionCode
-          .split('\n')
-          .map((line) => line.trim())
-          .join('\n');
-
-        mergedCode += `${testExecutionCode}`;
-      });
-
-      // add the internal after all invocation
-      mergedCode += `test_framework_internal_afterAll()\n`;
-    }
+    mergedCode += `\ntest_framework_initialize("${host}", ${port})\n`;
+    mergedCode = URTestUtils.appendTestCases(mergedCode, testCode);
+    mergedCode += `test_framework_internal_afterAll()\n`;
 
     return mergedCode;
-  }
-
-  private async injectFormatting(code: string): Promise<string> {
-    let tabbedCode = code;
-
-    if (tabbedCode) {
-      // inject tabs into each line of modified script
-      tabbedCode = tabbedCode
-        .split('\n')
-        .map((line) => `\t${line}`)
-        .join('\n');
-    }
-
-    return tabbedCode;
   }
 
   private async injectFramework(code: string): Promise<string> {
@@ -291,7 +166,7 @@ export class TestExecutionService implements ITestExecutionService {
 
     return code.replace(
       /{{.*test_framework_code.*}}/,
-      await this.injectFormatting(framework)
+      URTestUtils.formatCode(framework)
     );
   }
 
@@ -304,7 +179,7 @@ export class TestExecutionService implements ITestExecutionService {
     harness = await this.injectFramework(harness);
     harness = harness.replace(
       /{{.*test_script_code.*}}/,
-      await this.injectFormatting(code)
+      URTestUtils.formatCode(code)
     );
 
     return harness;

--- a/src/util/URTestUtils.ts
+++ b/src/util/URTestUtils.ts
@@ -1,9 +1,149 @@
+import * as fs from 'fs';
+import { promisify } from 'util';
+
+import { FilePattern } from '../bundler/types';
+import { getFilePaths } from './BundleUtils';
+
+const readFile = promisify(fs.readFile);
+
 export class URTestUtils {
-  public static extractMocks(testCode): string[] {
+  public static async appendCodeFromFilePattern(
+    baseCode: string,
+    pattern: FilePattern
+  ): Promise<string> {
+    if (pattern) {
+      const files = getFilePaths(pattern);
+
+      let merged = baseCode;
+      if (files) {
+        for (let f of files) {
+          const buffer = await readFile(f);
+          const contents = buffer.toString();
+          merged = this.appendCode(merged, `# ${f}\n\n${contents}`);
+        }
+      }
+
+      return merged;
+    }
+
+    return baseCode;
+  }
+
+  public static appendCode(baseCode: string, codeToAppend: string) {
+    return `${baseCode}\n${codeToAppend}\n`;
+  }
+
+  public static formatCode(code: string): string {
+    let tabbedCode = code;
+
+    if (tabbedCode) {
+      // inject tabs into each line of modified script
+      tabbedCode = tabbedCode
+        .split('\n')
+        .map((line) => `\t${line}`)
+        .join('\n');
+    }
+
+    return tabbedCode;
+  }
+
+  public static appendTestCases(baseCode: string, testCode: string): string {
+    const tests = URTestUtils.getTestDefinitions(testCode);
+
+    let mergedCode: string = baseCode;
+
+    if (tests) {
+      const testLifecycleBeforeEach = URTestUtils.getDefinitionByRegex(
+        testCode,
+        /.*beforeEach\(/g
+      );
+      const testLifecycleAfterEach = URTestUtils.getDefinitionByRegex(
+        testCode,
+        /.*afterEach\(/g
+      );
+
+      const hasBeforeEach =
+        testLifecycleBeforeEach && testLifecycleBeforeEach.length === 1
+          ? true
+          : false;
+
+      const hasAfterEach =
+        testLifecycleAfterEach && testLifecycleAfterEach.length === 1
+          ? true
+          : false;
+
+      tests.forEach((test) => {
+        let testExecutionCode = `
+          test_framework_internal_beforeEach("${test}")
+          ${hasBeforeEach ? 'beforeEach()' : ''}
+          ${test}()
+          ${hasAfterEach ? 'afterEach()' : ''}
+          test_framework_internal_afterEach("${test}")
+        `;
+
+        testExecutionCode = testExecutionCode
+          .split('\n')
+          .map((line) => line.trim())
+          .join('\n');
+
+        mergedCode += `${testExecutionCode}`;
+      });
+    }
+
+    return mergedCode;
+  }
+
+  public static replaceInvocationsWithMocks(
+    baseCode: string,
+    mockNames: string[]
+  ): string {
+    let mockedCode = baseCode;
+
+    if (mockNames && mockNames.length > 0) {
+      // replace function definition in the merged file with
+      // the mock implementation function name
+
+      for (const mock of mockNames) {
+        // get the function name to override
+        const overrideFunctionName = mock.replace(/mock\_/, '');
+
+        // replace references of the override name in the merged script
+        // with the mock function name
+
+        mockedCode = mockedCode
+          .split('\n')
+          .map((line) => {
+            let modified = line.trim();
+
+            if (
+              modified.startsWith('def') ||
+              modified.startsWith('thread') ||
+              modified.startsWith('#')
+            ) {
+              return line;
+            }
+
+            if (modified.indexOf(overrideFunctionName) > -1) {
+              return line.replace(
+                new RegExp(`(?<!_|[A-Za-z])${overrideFunctionName}\\(`, 'g'),
+                `${mock}(`
+              );
+            }
+
+            return line;
+          })
+          .join('\n');
+      }
+    }
+
+    return mockedCode;
+  }
+
+  public static getMockDefinitions(testCode: string): string[] {
     return this.getDefinitionByRegex(testCode, /.*mock_.+\(/g);
   }
 
-  public static extractTests(testCode): string[] {
+  public static getTestDefinitions(testCode: string): string[] {
     return this.getDefinitionByRegex(testCode, /.*def.*test_.+\(/g);
   }
 

--- a/src/util/URTestUtils.ts
+++ b/src/util/URTestUtils.ts
@@ -1,0 +1,25 @@
+export class URTestUtils {
+  public static extractMocks(testCode): string[] {
+    return this.getDefinitionByRegex(testCode, /.*mock_.+\(/g);
+  }
+
+  public static extractTests(testCode): string[] {
+    return this.getDefinitionByRegex(testCode, /.*def.*test_.+\(/g);
+  }
+
+  public static getDefinitionByRegex(
+    code: string,
+    regex: RegExp
+  ): Array<string> {
+    const results = code.match(regex);
+
+    if (results) {
+      return results
+        .map((t) => t.trim())
+        .filter((t) => !t.startsWith('#'))
+        .map((t) => t.replace(/^(def|thread)[\s]*/g, '').replace('(', ''));
+    }
+
+    return [];
+  }
+}

--- a/src/util/__tests__/URTestUtils.test.ts
+++ b/src/util/__tests__/URTestUtils.test.ts
@@ -1,0 +1,30 @@
+import { URTestUtils } from '../URTestUtils';
+
+describe('URTestUtils', () => {
+  test('extract - tests', () => {
+    const testCode = `
+      def test_helloWorld():
+      end
+      def test_again():
+      end
+    `;
+
+    const tests = URTestUtils.extractTests(testCode);
+
+    expect(tests).toEqual(['test_helloWorld', 'test_again']);
+  });
+
+  test('extract - name includes keyword - def | thread', () => {
+    const testCode = `
+      def test_some_default_test():
+      end
+
+      def test_thread():
+      end
+    `;
+
+    const tests = URTestUtils.extractTests(testCode);
+
+    expect(tests).toEqual(['test_some_default_test', 'test_thread']);
+  });
+});

--- a/src/util/__tests__/URTestUtils.test.ts
+++ b/src/util/__tests__/URTestUtils.test.ts
@@ -35,24 +35,6 @@ describe('URTestUtils', () => {
     expect(tests).toEqual(['test_some_default_test', 'test_thread']);
   });
 
-  test('append code', async () => {
-    const main: string = `
-      # some code here
-    `;
-
-    const codeToAppend: string = `
-      def mock_textmsg(msg1, msg2 = ""):
-        # code
-      end
-    `;
-
-    const expected: string = `${main}\n${codeToAppend}\n`;
-
-    const result: string = URTestUtils.appendCode(main, codeToAppend);
-
-    expect(result).toEqual(expected);
-  });
-
   test('append code - string', async () => {
     const baseCode: string = `
       # some code here

--- a/src/util/__tests__/URTestUtils.test.ts
+++ b/src/util/__tests__/URTestUtils.test.ts
@@ -1,4 +1,11 @@
+import * as fs from 'fs';
+import { promisify } from 'util';
+
+import { FilePattern } from '../../bundler/types';
 import { URTestUtils } from '../URTestUtils';
+
+const writeFile = promisify(fs.writeFile);
+const unlink = promisify(fs.unlink);
 
 describe('URTestUtils', () => {
   test('extract - tests', () => {
@@ -9,7 +16,7 @@ describe('URTestUtils', () => {
       end
     `;
 
-    const tests = URTestUtils.extractTests(testCode);
+    const tests = URTestUtils.getTestDefinitions(testCode);
 
     expect(tests).toEqual(['test_helloWorld', 'test_again']);
   });
@@ -23,8 +30,170 @@ describe('URTestUtils', () => {
       end
     `;
 
-    const tests = URTestUtils.extractTests(testCode);
+    const tests = URTestUtils.getTestDefinitions(testCode);
 
     expect(tests).toEqual(['test_some_default_test', 'test_thread']);
+  });
+
+  test('append code', async () => {
+    const main: string = `
+      # some code here
+    `;
+
+    const codeToAppend: string = `
+      def mock_textmsg(msg1, msg2 = ""):
+        # code
+      end
+    `;
+
+    const expected: string = `${main}\n${codeToAppend}\n`;
+
+    const result: string = URTestUtils.appendCode(main, codeToAppend);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('append code - string', async () => {
+    const baseCode: string = `
+      # some code here
+    `;
+
+    const codeToAppend: string = `
+      def mock_textmsg(msg1, msg2 = ""):
+        # code
+      end
+    `;
+
+    const expected: string = `${baseCode}\n${codeToAppend}\n`;
+
+    const result: string = URTestUtils.appendCode(baseCode, codeToAppend);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('append code - file pattern', async () => {
+    const file1: string = `/tmp/${Date.now()}`;
+    const file2: string = `/tmp/${Date.now() + 1}`;
+
+    const file1Contents: string = `
+      def mock_one():
+      end
+    `;
+
+    const file2Contents: string = `
+      def mock_two():
+      end
+    `;
+
+    await writeFile(file1, file1Contents);
+    await writeFile(file2, file2Contents);
+
+    const pattern: FilePattern = {
+      include: [file1, file2],
+    };
+
+    const baseCode: string = `
+      # some code here
+    `;
+
+    const result: string = await URTestUtils.appendCodeFromFilePattern(
+      baseCode,
+      pattern
+    );
+
+    await unlink(file1);
+    await unlink(file2);
+
+    expect(result).toContain(file1Contents);
+    expect(result).toContain(file2Contents);
+  });
+
+  test('replace inovcations - mocks', async () => {
+    const baseCode: string = `
+      invocationToReplace()
+      anotherFunction()
+      helloWorld()
+    `;
+
+    const expected: string = `
+      mock_invocationToReplace()
+      anotherFunction()
+      mock_helloWorld()
+    `;
+
+    const result: string = URTestUtils.replaceInvocationsWithMocks(baseCode, [
+      'mock_invocationToReplace',
+      'mock_helloWorld',
+    ]);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('replace inovcations - mock name exist in another function name - https://github.com/Hirebotics/urscript-tools/issues/12', async () => {
+    const baseCode: string = `
+      hbmovel()
+    `;
+
+    const expected: string = `
+      hbmovel()
+    `;
+
+    const result: string = URTestUtils.replaceInvocationsWithMocks(baseCode, [
+      'mock_movel',
+    ]);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('append test cases', async () => {
+    const baseCode: string = `
+      hbmovel()
+    `;
+
+    const testCode: string = `
+      def test_hello():
+      end
+    `;
+
+    const expected = `
+      hbmovel()
+      test_framework_internal_beforeEach("test_hello")
+      test_hello()
+      test_framework_internal_afterEach("test_hello")
+    `;
+
+    const result = URTestUtils.appendTestCases(baseCode, testCode);
+
+    expect(result.replace(/\s/g, '')).toEqual(expected.replace(/\s/g, ''));
+  });
+
+  test('append test cases - before each / after each', async () => {
+    const baseCode: string = `
+      hbmovel()
+    `;
+
+    const testCode: string = `
+      def beforeEach():
+      end
+
+      def afterEach():
+      end
+
+      def test_hello():
+      end
+    `;
+
+    const expected = `
+      hbmovel()
+      test_framework_internal_beforeEach("test_hello")
+      beforeEach()
+      test_hello()
+      afterEach()
+      test_framework_internal_afterEach("test_hello")
+    `;
+
+    const result = URTestUtils.appendTestCases(baseCode, testCode);
+
+    expect(result.replace(/\s/g, '')).toEqual(expected.replace(/\s/g, ''));
   });
 });


### PR DESCRIPTION
**Features**
Adds new option to strip comments from bundle script. Default value is off. 

**Bugs**
- Fixes #12 
- Fixes issue where bundle key was required and not using the default
- Fixes scenario where a test name would get malformed if it contained a keyword like def or thread