### PR TITLE
fix: added TEST_HOST and TEST_PORT global variables

### DIFF
--- a/src/urtester/templates/framework.script
+++ b/src/urtester/templates/framework.script
@@ -6,6 +6,9 @@ global TEST_LAST_RESULT = "passed"
 global TEST_LAST_RESULT_MESSAGE = ""
 
 def test_framework_initialize(host, port):
+  global TEST_HOST = host
+  global TEST_PORT = port
+
   socket_open(host, port, TEST_SOCKET_NAME)
 
   local type = test_framework_internal_createKeyValuePair("type", "EXECUTION_STARTED", False)


### PR DESCRIPTION
PR exposes the host and port as global variables which can be used by test cases to initiate server connections on the main host outside of the test framework Docker container.